### PR TITLE
remove unnecessary hub account steps

### DIFF
--- a/content/en/docs/CommunityLeaders/EventHandbooks/Docker101/registry/_index.md
+++ b/content/en/docs/CommunityLeaders/EventHandbooks/Docker101/registry/_index.md
@@ -34,7 +34,6 @@ description: >-
 
 ### Pre-requisite
 
-- Create an account with [DockerHub](https://hub.docker.com)
 - Open [PWD](https://labs.play-with-docker.com/) Platform on your browser 
 - Click on **Add New Instance** on the left side of the screen to bring up Alpine OS instance on the right side
 
@@ -43,12 +42,6 @@ description: >-
 
 ```
 $ mkdir -p /registry/data
-```
-
-### Authenticate with DockerHub
-
-```
-$docker login
 ```
 
 ### Start the registry container.


### PR DESCRIPTION
no docker hub account is needed here to pull the `registry:2` image